### PR TITLE
Replacing deprecated \clearscrheadfoot

### DIFF
--- a/erc.cls
+++ b/erc.cls
@@ -59,7 +59,7 @@
 
 \RequirePackage{scrlayer-scrpage}
 \pagestyle{scrheadings}
-\clearscrheadfoot
+\clearpairofpagestyles
 \renewcommand{\headfont}{\normalfont}
 \ihead[\emph{\@authorshort}]{\emph{\@authorshort}}
 


### PR DESCRIPTION
Replacing deprecated \clearscrheadfoot by \clearpairofpagestyles